### PR TITLE
Improve breadcrumbs

### DIFF
--- a/src/app/header.tpl.html
+++ b/src/app/header.tpl.html
@@ -36,11 +36,11 @@
     </div>
     <div>
         <ul class="breadcrumb">
-            <li ng-repeat="breadcrumb in pathElements" class="active">
+            <li ng-repeat="breadcrumb in breadcrumbs">
                 <span class="divider">/</span>
                 <ng-switch on="$last">
-                    <span ng-switch-when="true">{{breadcrumb}}</span>
-                    <span ng-switch-default><a href="{{breadcrumbPath($index)}}">{{breadcrumb}}</a></span>
+                    <span ng-switch-when="true">{{breadcrumb.name}}</span>
+                    <span ng-switch-default><a href="{{breadcrumb.path}}">{{breadcrumb.name}}</a></span>
                 </ng-switch>
             </li>
         </ul>


### PR DESCRIPTION
So, here is my second take at the breadcrumbs, much smaller in scale... Basically I've just changed breadcrumbs construction strategy from `$location` watching to route change success event. This way breadcrumbs get updated only when the route navigation takes place (and stay untouched if route navigation fails).

This is not a huge change but still makes application behave more 'sane', visually speaking.
