### PR TITLE
Manual login

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -10,9 +10,12 @@ angular.module('app').config(['$routeProvider', '$locationProvider', function ($
   $routeProvider.otherwise({redirectTo:'/dashboard'});
 }]);
 
-angular.module('app').controller('AppCtrl', ['$scope', '$location', '$route', 'HTTPRequestTracker', function ($scope, $location, $route, HTTPRequestTracker) {
-  $scope.location = $location;
+angular.module('app').controller('AppCtrl', [function() {}]);
 
+angular.module('app').controller('HeaderCtrl', ['$scope', '$location', '$route', 'currentUser', 'HTTPRequestTracker', function ($scope, $location, $route, currentUser, HTTPRequestTracker) {
+  $scope.location = $location;
+  $scope.currentUser = currentUser;
+  
   $scope.isNavbarActive = function (navBarPath) {
     return navBarPath === $scope.pathElements[0];
   };

--- a/src/app/header.tpl.html
+++ b/src/app/header.tpl.html
@@ -1,13 +1,13 @@
-<div class="navbar">
+<div class="navbar" ng-controller="HeaderCtrl">
     <div class="navbar-inner">
         <a class="brand" href="/">AScrum</a>
         <ul class="nav">
             <li ng-class="{active:isNavbarActive('projectsInfo')}"><a>Projects info</a></li>
         </ul>
 
-        <ul class="nav" ng-show="authService.currentUser">
+        <ul class="nav" ng-show="currentUser.isAuthenticated()">
             <li ng-class="{active:isNavbarActive('projects')}"><a href="/projects">My projects</a></li>
-            <li class="dropdown" ng-class="{active:isNavbarActive('admin'), open:isAdminOpen}">
+            <li class="dropdown" ng-class="{active:isNavbarActive('admin'), open:isAdminOpen}" ng-show="currentUser.isAdmin()">
                 <a id="adminmenu" role="button" class="dropdown-toggle" ng-click="isAdminOpen=!isAdminOpen">Admin<b class="caret"></b></a>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="adminmenu">
                     <li><a tabindex="-1" href="/admin/projects" ng-click="isAdminOpen=false">Projects</a></li>

--- a/src/app/login/form.tpl.html
+++ b/src/app/login/form.tpl.html
@@ -1,4 +1,4 @@
-<div class="modal" show="showLoginForm">
+<div class="modal" ng-show="showLoginForm">
     <div class="modal-header">
         <h4>Sign in</h4>
     </div>

--- a/src/app/login/login.js
+++ b/src/app/login/login.js
@@ -50,14 +50,15 @@ angular.module('login', ['services.authentication', 'directives.modal']).directi
   return directive;
 }]);
 
-angular.module('login').directive('loginToolbar', ['AuthenticationService', function(AuthenticationService) {
+angular.module('login').directive('loginToolbar', ['currentUser', 'AuthenticationService', function(currentUser, AuthenticationService) {
   var directive = {
     templateUrl: 'login/toolbar.tpl.html',
     restrict: 'E',
     replace: true,
     scope: true,
     link: function($scope, $element, $attrs, $controller) {
-      $scope.$watch(function() { return AuthenticationService.currentUser; }, function(value) { $scope.currentUser = value; });
+      $scope.userInfo = currentUser.info;
+      $scope.isAuthenticated = currentUser.isAuthenticated;
       $scope.logout = function() { AuthenticationService.logout(); };
       $scope.login = function() { AuthenticationService.showLogin(); };
     }

--- a/src/app/login/toolbar.tpl.html
+++ b/src/app/login/toolbar.tpl.html
@@ -1,14 +1,14 @@
 <ul class="nav pull-right">
   <li class="divider-vertical"></li>
   <li ng-show="currentUser">
-      <a href="#">{{currentUser.firstName}} {{currentUser.lastName}}</a>
+      <a href="#">{{userInfo().firstName}} {{userInfo().lastName}}</a>
   </li>
-  <li ng-show="currentUser">
+  <li ng-show="isAuthenticated()">
       <form class="navbar-form">
           <button class="btn" ng-click="logout()">Log out</button>
       </form>
   </li>
-  <li ng-hide="currentUser">
+  <li ng-hide="isAuthenticated()">
       <form class="navbar-form">
           <button class="btn" ng-click="login()">Log in</button>
       </form>

--- a/src/common/services/authentication.js
+++ b/src/common/services/authentication.js
@@ -1,10 +1,22 @@
 // Based loosely around work by Witold Szczerba - https://github.com/witoldsz/angular-http-auth
 angular.module('services.authentication', []);
 
+// The current user.  You can watch this for changes due to logging in and out
+angular.module('services.authentication').factory('currentUser', function() {
+  var userInfo = null;
+  var currentUser = {
+    update: function(info) { userInfo = info; },
+    info: function() { return userInfo; },
+    isAuthenticated: function(){ return !!userInfo; },
+    isAdmin: function() { return !!(userInfo && userInfo.admin); }
+  };
+  return currentUser;
+});
+
 // The AuthenticationService is the public API for this module.  Application developers should only need to use this service and not any of the others here.
 // The general idea is that you watch isLoginRequired for a change to true.  This happens when a http request returns 401 unauthorized. When this happens you need to show your login dialog box.
 // When the user has successfully logged in you call loginConfirmed to retry any queued requests.
-angular.module('services.authentication').factory('AuthenticationService', ['$rootScope', '$http', '$location', 'AuthenticationRequestRetryQueue', function($rootScope, $http, $location, queue) {
+angular.module('services.authentication').factory('AuthenticationService', ['$rootScope', '$http', '$location', 'AuthenticationRequestRetryQueue', 'currentUser', function($rootScope, $http, $location, queue, currentUser) {
 
   function retryRequest(next) {
     $http(next.request.config).then(function(response) {
@@ -20,16 +32,13 @@ angular.module('services.authentication').factory('AuthenticationService', ['$ro
   }
 
   var service = {
-    // The info about the current authenticated user after a login
-    currentUser: null,
-
     // Login to the back end - on success will trigger
     login: function(email, password) {
       var request = $http.post('/login', {email: email, password: password});
       return request.then(function(response) {
         var user = response.data.user;
+        currentUser.update(user);
         if ( user !== null ) {
-          service.currentUser = user;
           queue.process(retryRequest);
         }
         return user;
@@ -43,7 +52,7 @@ angular.module('services.authentication').factory('AuthenticationService', ['$ro
 
     logout: function(redirectTo) {
       $http.post('/logout').then(function() {
-        service.currentUser = null;
+        currentUser.update(null);
         redirect();
       });
     },
@@ -52,7 +61,7 @@ angular.module('services.authentication').factory('AuthenticationService', ['$ro
     // The app should probably do this at start up
     requestCurrentUser: function() {
       return $http.get('/current-user').then(function(response) {
-        service.currentUser = response.data.user;
+        currentUser.update(response.data.user);
         return response;
       });
     },
@@ -65,10 +74,8 @@ angular.module('services.authentication').factory('AuthenticationService', ['$ro
 
   // Watch the retry queue and raise an event if the queue goes from no items to some items
   $rootScope.$watch(function() { return queue.hasMore(); }, function(value, oldValue, other) {
-    console.log(value, oldValue, other);
     if ( value ) {
-      console.log('raising');
-      if ( service.currentUser ) {
+      if ( currentUser.isAuthenticated() ) {
         // If a user is already logged in then they must not have the required permissions
         service.showLogin('unauthorized');
       } else {


### PR DESCRIPTION
Fixed up the login so that you can now login and logout manually.  Still has the backend security checks.  But we now need to add in route-based security on the client side.
This has a number of refactorings, including:
- extracting the login-toolbar stuff into a directive
- extracting the currentUser stuff into a separate service
- making the Authentication service the event emitter rather than the queue.
- using different kind of events to trigger different kinds of logins.
- moved header specific functionality into a HeaderCtrl that is local to the header template.

Feel free to merge if you like it.
