### PR TITLE
General purpose notification service

### DIFF
--- a/src/common/services/notifications.js
+++ b/src/common/services/notifications.js
@@ -1,6 +1,5 @@
-angular.module('services.notifications', []);
+angular.module('services.notifications', []).factory('notifications', function ($rootScope) {
 
-angular.module('services.notifications').factory('notifications', function ($rootScope) {
 
   // A factory to create a notification list object that manages its own notifications
   var createNotificationList = function() {
@@ -14,8 +13,10 @@ angular.module('services.notifications').factory('notifications', function ($roo
         var notification = {
           message: message,
           type: type || 'info',
-          remove: function() {
-            notificationList.remove(notification);
+          $remove: function() {
+            notificationList.remove(function(notificationInList) {
+              return notification === notificationInList;
+            });
           }
         };
         return angular.extend(notification, options);
@@ -53,16 +54,8 @@ angular.module('services.notifications').factory('notifications', function ($roo
   var notificationLists = {};
   var includeInCurrent = [];
   var notificationsService = {
-    // Returns a concatenated array of all the notifications from all the lists in the service
-    all: function() {
-      var notifications = [];
-      angular.forEach(notificationLists, function(list) {
-        notifications = notifications.concat(list.getAll());
-      });
-      return notifications;
-    },
 
-    current: function() {
+    getCurrent: function() {
       var notifications = [];
       angular.forEach(includeInCurrent, function(listName) {
         notifications = notifications.concat(notificationLists[listName].getAll());
@@ -108,7 +101,7 @@ angular.module('services.notifications').factory('notifications', function ($roo
   };
 
   function pushFunctionName(listName) {
-    return 'push'+listName+'Notification';
+    return 'push'+listName;
   }
 
   // Add and configure a new list in the notification service.
@@ -125,16 +118,16 @@ angular.module('services.notifications').factory('notifications', function ($roo
   }
 
   addNotificationListToService('Sticky');
-  addNotificationListToService('CurrentRoute');
-  addNotificationListToService('NextRoute');
+  addNotificationListToService('ForCurrentRoute');
+  addNotificationListToService('ForNextRoute');
 
   includeInCurrent.push('Sticky');
-  includeInCurrent.push('CurrentRoute');
+  includeInCurrent.push('ForCurrentRoute');
 
   // Rewire the CurrentRoute and NextRoute notification lists when the route changes
   $rootScope.$on('$routeChangeSuccess', function () {
-    moveNotificationList('NextRoute', 'CurrentRoute');
-    addNotificationListToService('NextRoute');
+    moveNotificationList('ForNextRoute', 'ForCurrentRoute');
+    addNotificationListToService('ForNextRoute');
   });
 
   return notificationsService;

--- a/test/unit/common/services/notificationsSpec.js
+++ b/test/unit/common/services/notificationsSpec.js
@@ -10,30 +10,34 @@ describe('notifications', function () {
   describe('global notifications crud', function () {
 
     it('should allow to add, get and remove notifications', function () {
-      var not1 = notifications.pushStickyNotification('Watch out!', 'alert');
-      var not2 = notifications.pushStickyNotification('Just an info!', 'info');
+      var not1 = notifications.pushSticky('Watch out!', 'alert');
+      var not2 = notifications.pushSticky('Just an info!', 'info');
 
-      expect(notifications.current().length).toEqual(2);
-      expect(notifications.current()[0]).toBe(not1);
+      expect(notifications.getCurrent().length).toEqual(2);
+      expect(notifications.getCurrent()[0]).toBe(not1);
 
       notifications.remove(not2);
-      expect(notifications.current().length).toEqual(1);
-      expect(notifications.current()[0]).toBe(not1);
+      expect(notifications.getCurrent().length).toEqual(1);
+      expect(notifications.getCurrent()[0]).toBe(not1);
 
       notifications.removeAll();
-      expect(notifications.current().length).toEqual(0);
+      expect(notifications.getCurrent().length).toEqual(0);
+    });
+
+    it('removeal of a non-existing notification doesnt trigger errors', function () {
+      notifications.remove({});
     });
   });
 
   describe('notifications expiring after route change', function () {
 
     it('should remove notification after route change', function () {
-      var sticky = notifications.pushStickyNotification('Will stick around after route change');
-      var currentRoute = notifications.pushCurrentRouteNotification('Will go away after route change');
-      expect(notifications.current().length).toEqual(2);
+      var sticky = notifications.pushSticky('Will stick around after route change');
+      var currentRoute = notifications.pushForCurrentRoute('Will go away after route change');
+      expect(notifications.getCurrent().length).toEqual(2);
       $scope.$emit('$routeChangeSuccess');
-      expect(notifications.current().length).toEqual(1);
-      expect(notifications.current()[0]).toBe(sticky);
+      expect(notifications.getCurrent().length).toEqual(1);
+      expect(notifications.getCurrent()[0]).toBe(sticky);
     });
   });
 
@@ -41,13 +45,23 @@ describe('notifications', function () {
   describe('notifications showing on next route change and expiring on a subsequent one', function () {
 
     it('should advertise a notification after a route change and remove on the subsequent route change', function () {
-      notifications.pushStickyNotification('Will stick around after route change');
-      notifications.pushNextRouteNotification('Will not be there till after route change');
-      expect(notifications.current().length).toEqual(1);
+      notifications.pushSticky('Will stick around after route change');
+      notifications.pushForNextRoute('Will not be there till after route change');
+      expect(notifications.getCurrent().length).toEqual(1);
       $scope.$emit('$routeChangeSuccess');
-      expect(notifications.current().length).toEqual(2);
+      expect(notifications.getCurrent().length).toEqual(2);
       $scope.$emit('$routeChangeSuccess');
-      expect(notifications.current().length).toEqual(1);
+      expect(notifications.getCurrent().length).toEqual(1);
+    });
+  });
+
+  describe('removing a notification instance', function () {
+
+    it('should allow removal of notification instances', function () {
+      var sticky = notifications.pushSticky('Will be removed!');
+      expect(notifications.getCurrent().length).toEqual(1);
+     notifications.getCurrent()[0].$remove();
+     expect(notifications.getCurrent().length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
Should address #67

Made it a bit more general, so we could push any type of objects. A notification will be removed based on a category to which it was pushed.

This could be further extended (for example to evict notifications using the `$timeout` service) and probably coded in the way that is more generic but since we don't have any uses-cases for this right now the current version should do.

@petebacondarwin please review / comment / merge.
