### PR TITLE
localizedMessages service

### DIFF
--- a/src/common/services/localizedMessages.js
+++ b/src/common/services/localizedMessages.js
@@ -1,0 +1,31 @@
+angular.module('services.localizedMessages', []).factory('localizedMessages', ['$locale', '$interpolate', 'I18N.MESSAGES', 'I18N.DEFAULT_LOCALE', function ($locale, $interpolate, i18nmessages, i18ndefaultLocale) {
+
+  var defaultLocale = i18ndefaultLocale;
+  var getForLocale = function(locale, msgKey, handleNotFound) {
+    return (i18nmessages[locale] || {})[msgKey];
+  };
+
+  var handleNotFound = function(msg, msgKey) {
+    return msg || '?'+msgKey+'?';
+  };
+
+  var msgService = {};
+   msgService.get = function(msgKey, interpolateParams) {
+     return msgService.getForLocale(msgKey, $locale.id, interpolateParams)
+   };
+
+    msgService.getForLocale = function(msgKey, locale, interpolateParams) {
+      var msgForLocale = getForLocale(locale || $locale.id, msgKey);
+      if (!msgForLocale && locale !== defaultLocale) {
+        msgForLocale =  getForLocale(defaultLocale, msgKey, true);
+      }
+
+      if (msgForLocale) {
+        return $interpolate(msgForLocale)(interpolateParams);
+      } else {
+        return handleNotFound(msgForLocale, msgKey);
+      }
+    };
+
+  return msgService;
+}]);

--- a/test/unit/common/services/localizedMessagesSpec.js
+++ b/test/unit/common/services/localizedMessagesSpec.js
@@ -1,0 +1,71 @@
+describe('localized messages', function () {
+
+  var $locale, localizedMessages, messages;
+  beforeEach(function () {
+    angular.module('test',['services.localizedMessages'])
+      .value('I18N.MESSAGES', messages = {})
+      .constant('I18N.DEFAULT_LOCALE', 'en-us');
+    module('test');
+  });
+  beforeEach(inject(function (_$locale_, _localizedMessages_) {
+    $locale = _$locale_;
+    localizedMessages = _localizedMessages_;
+  }));
+
+  describe('messages for the current locale', function () {
+
+    it('should return a localized message if defined', function () {
+      messages['en-us'] = {existing:'Existing message!'};
+      expect(localizedMessages.get('existing')).toEqual('Existing message!');
+    });
+
+    it('should return a message key surrounded by a question mark for non-existing messages', function () {
+      expect(localizedMessages.get('non.existing')).toEqual('?non.existing?');
+    });
+  });
+
+  describe('messages for a specified locale', function () {
+
+    it('should return a message for a specified locale if exists', function () {
+      messages['fr-fr'] = {sth:'quelque chose'};
+      expect(localizedMessages.getForLocale('sth', 'fr-fr')).toEqual('quelque chose');
+    });
+
+    it('should return a message from the default locale if doesnt exist in a specified one', function () {
+      messages['en-us'] = {sth:'something'};
+      expect(localizedMessages.getForLocale('sth', 'fr-fr')).toEqual('something');
+    });
+
+    it('should allow using forLocale even for the current locale', function () {
+      messages['en-us'] = {sth:'something'};
+      expect(localizedMessages.getForLocale('sth', 'en-us')).toEqual('something');
+    });
+
+    it('should return a message key surrounded by a question mark for non-existing messages when locale was specified', function () {
+      expect(localizedMessages.getForLocale('sth', 'fr-fr')).toEqual('?sth?');
+    });
+  });
+
+  describe('interpolation of message parameters', function () {
+
+    it('should interpolate parameters for the current locale', function () {
+      messages['en-us'] = {sth:'en {{param}} us'};
+      expect(localizedMessages.get('sth', {param:'value'})).toEqual('en value us');
+    });
+
+    it('should interpolate parameters for a specified locale', function () {
+      messages['en-us'] = {sth:'en {{param}} us'};
+      expect(localizedMessages.getForLocale('sth', 'en-us', {param:'value'})).toEqual('en value us');
+    });
+
+    it('should not break for missing params', function () {
+      messages['en-us'] = {sth:'en {{param}} us'};
+      expect(localizedMessages.getForLocale('sth', 'en-us')).toEqual('en  us');
+      expect(localizedMessages.getForLocale('sth', 'en-us', {other:'value'})).toEqual('en  us');
+
+      expect(localizedMessages.get('sth')).toEqual('en  us');
+      expect(localizedMessages.get('sth', {other:'value'})).toEqual('en  us');
+    });
+
+  });
+});


### PR DESCRIPTION
Another fundamental service for our app, essential for introducing i18n support. It has built-in support for multiple locales and localized messages interpolation.

The only part that is not clear for me is how on earth we are going to load localized messages :-)
For now I'm assuming that we are going to generate them during the build time and create a module with a constant containing all messages. The point here is that this is such a low level service that we can't wait for the messages downloading, those need to come with the very first response from the server (the one serving index.html).

To be reviewed / criticized and merged :-)
