### PR TITLE
Integrating modal from angular-ui/bootstrap

### DIFF
--- a/src/app/login/form.tpl.html
+++ b/src/app/login/form.tpl.html
@@ -1,4 +1,4 @@
-<div class="modal" ng-show="showLoginForm">
+<div modal="showLoginForm" close="cancelLogin()">
     <div class="modal-header">
         <h4>Sign in</h4>
     </div>

--- a/src/common/directives/modal.js
+++ b/src/common/directives/modal.js
@@ -1,23 +1,75 @@
-angular.module('directives.modal', []).directive('modal', ['$parse', function($parse){
-  var directive = {
-    restrict: 'C',
-    link: function($scope, $element, $attrs, $controller){
-      var showFn = $parse($attrs.show);
+angular.module('directives.modal', []).directive('modal', ['$parse',function($parse) {
+  var backdropEl;
+  var body = angular.element(document.getElementsByTagName('body')[0]);
+  var defaultOpts = {
+    backdrop: true,
+    escape: true
+  };
+  return {
+    restrict: 'ECA',
+    link: function(scope, elm, attrs) {
+      var opts = angular.extend(defaultOpts, scope.$eval(attrs.uiOptions || attrs.bsOptions || attrs.options));
+      var shownExpr = attrs.modal || attrs.show;
+      var setClosed;
 
-      if ( !$element.modal ) {
-        throw new Error("Modal directive requires Twitter Bootstrap Modal library");
+      if (attrs.close) {
+        setClosed = function() {
+          scope.$apply(attrs.close);
+        };
+      } else {
+        setClosed = function() {
+          scope.$apply(function() {
+            $parse(shownExpr).assign(scope, false);
+          });
+        };
+      }
+      elm.addClass('modal');
+
+      if (opts.backdrop && !backdropEl) {
+        backdropEl = angular.element('<div class="modal-backdrop"></div>');
+        backdropEl.css('display','none');
+        body.append(backdropEl);
       }
 
-      $element.modal({ backdrop: $attrs.backdrop, keyboard: $attrs.keyboard, show: showFn($scope) });
+      function setShown(shown) {
+        scope.$apply(function() {
+          model.assign(scope, shown);
+        });
+      }
 
-      $scope.$watch($attrs.show, function(value) {
-        if ( value ) {
-          $element.modal('show');
+      function escapeClose(evt) {
+        if (evt.which === 27) { setClosed(); }
+      }
+      function clickClose() {
+        setClosed();
+      }
+
+      function close() {
+        if (opts.escape) { body.unbind('keyup', escapeClose); }
+        if (opts.backdrop) {
+          backdropEl.css('display', 'none').removeClass('in');
+          backdropEl.unbind('click', clickClose);
+        }
+        elm.css('display', 'none').removeClass('in');
+        body.removeClass('modal-open');
+      }
+      function open() {
+        if (opts.escape) { body.bind('keyup', escapeClose); }
+        if (opts.backdrop) {
+          backdropEl.css('display', 'block').addClass('in');
+          backdropEl.bind('click', clickClose);
+        }
+        elm.css('display', 'block').addClass('in');
+        body.addClass('modal-open');
+      }
+
+      scope.$watch(shownExpr, function(isShown, oldShown) {
+        if (isShown) {
+          open();
         } else {
-          $element.modal('hide');
+          close();
         }
       });
     }
   };
-  return directive;
 }]);


### PR DESCRIPTION
@petebacondarwin Peter, tried out the modal impl from angular-ui/boostrap and it seem to be working OK. It brings back support for backdrop and ESC (where escape correctly handles login cancelation).

Up to you to decide what to do with this one, I guess it really depends on what you want to show in the chapter devoted to integrating 3rd party directives. I don't know, we need to bring-in date picker at some point.

Anyway, it is here, seems to be working: merge or close this one, up to you.
