### PR TITLE
Testable exceptionHandler decorator delegation!

### DIFF
--- a/src/common/services/exceptionHandler.js
+++ b/src/common/services/exceptionHandler.js
@@ -1,15 +1,27 @@
-angular.module('services.exceptionHandler', ['services.notifications', 'services.localizedMessages'], ['$provide', function($provide) {
+angular.module('services.exceptionHandler', ['services.notifications', 'services.localizedMessages']);
 
-  $provide.decorator('$exceptionHandler',  ['$injector', '$delegate', 'localizedMessages', function ($injector, $delegate, localizedMessages) {
-
+angular.module('services.exceptionHandler').factory('exceptionHandlerFactory', ['$injector', 'localizedMessages', function($injector, localizedMessages) {
+  return function($delegate) {
+    var notifications;
     return function (exception, cause) {
-      //need to get the notications service from injector due to circular dependencies:
+      // Lazy load notifications to get around circular dependency
       //Circular dependency: $rootScope <- notifications <- $exceptionHandler
+      var notifications = notifications || $injector.get('notifications');
+
+      // Pass through to original handler
       $delegate(exception, cause);
-      $injector.get('notifications').pushForCurrentRoute(localizedMessages.get('error.fatal'), 'error', {
+
+      // Push a notification error
+      notifications.pushForCurrentRoute(localizedMessages.get('error.fatal'), 'error', {
         exception:exception,
         cause:cause
       });
     };
+  };
+}]);
+
+angular.module('services.exceptionHandler').config(['$provide', function($provide) {
+  $provide.decorator('$exceptionHandler', ['$delegate', 'exceptionHandlerFactory', function ($delegate, exceptionHandlerFactory) {
+    return exceptionHandlerFactory($delegate);
   }]);
 }]);

--- a/test/unit/common/services/exceptionHandlerSpec.js
+++ b/test/unit/common/services/exceptionHandlerSpec.js
@@ -36,4 +36,16 @@ describe('exception handler', function () {
       $exceptionHandler(new Error('root cause'));
     }).toThrow('issue with notifications');
   });
+
+  it('should call through to the delegate', function() {
+    inject(function(exceptionHandlerFactory) {
+      var error = new Error('Something went wrong...');
+      var cause = 'Some obscure problem...';
+
+      var delegate = jasmine.createSpy('delegate');
+      var exceptionHandler = exceptionHandlerFactory(delegate);
+      exceptionHandler(error, cause);
+      expect(delegate).toHaveBeenCalledWith(error, cause);
+    });
+  });
 });


### PR DESCRIPTION
Refactored decorator into a factory so that we can test that the delegate is called.

Is this just overkill or what?

If feel this is the way it ought to be done but that AngularJS should provide most of this plumbing to allow us access to the delegate at testing time.
