### PR TITLE
Fix bug on repeatedly opening login form

### DIFF
--- a/client/src/common/security/security.js
+++ b/client/src/common/security/security.js
@@ -18,8 +18,8 @@ angular.module('security.service', [
   function openLoginDialog() {
     if ( !loginDialog ) {
       loginDialog = $dialog.dialog();
-      loginDialog.open('security/login/form.tpl.html', 'LoginFormController').then(onLoginDialogClose);
     }
+    loginDialog.open('security/login/form.tpl.html', 'LoginFormController').then(onLoginDialogClose);
   }
   function closeLoginDialog(success) {
     if (loginDialog) {


### PR DESCRIPTION
Bug can be reproduced like this : 
- click on "login"
- click on "cancel" on the login form to close it
    (or click aside of the login form to close it) 
- click on "login" to open the login form again 
- Login form fails to open...
