### PR TITLE
fix for jshinting on the renamed server/gruntFile.js

### DIFF
--- a/server/gruntFile.js
+++ b/server/gruntFile.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
       tasks: 'default timestamp'
     },
     jshint: {
-      files: ['grunt.js', 'server.js', 'lib/*.js', 'test/**/*.js'],
+      files: ['gruntFile.js', 'server.js', 'lib/*.js', 'test/**/*.js'],
       options: {
         curly: true,
         eqeqeq: true,


### PR DESCRIPTION
I've renamed the `"grunt.js"` reference in your server's `gruntFile.js` to make sure your gruntFile is being linted by jshint again.
