### PR TITLE
Fixes bug in admin-projects.js that prevented adding team members

### DIFF
--- a/client/src/app/admin/projects/admin-projects.js
+++ b/client/src/app/admin/projects/admin-projects.js
@@ -37,7 +37,7 @@ angular.module('admin-projects', [
 .controller('ProjectsEditCtrl', ['$scope', '$location', 'i18nNotifications', 'users', 'project', function($scope, $location, i18nNotifications, users, project) {
 
   $scope.project = project;
-  $scope.selTeamMember = undefined;
+  $scope.sel = {teamMember: undefined};
 
   $scope.users = users;
   //prepare users lookup, just keep references for easier lookup
@@ -76,9 +76,9 @@ angular.module('admin-projects', [
   };
 
   $scope.addTeamMember = function() {
-    if($scope.selTeamMember) {
-      $scope.project.teamMembers.push($scope.selTeamMember);
-      $scope.selTeamMember = undefined;
+    if($scope.sel.teamMember) {
+      $scope.project.teamMembers.push($scope.sel.teamMember);
+      $scope.sel.teamMember = undefined;
     }
   };
 

--- a/client/src/app/admin/projects/projects-edit.tpl.html
+++ b/client/src/app/admin/projects/projects-edit.tpl.html
@@ -36,11 +36,11 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><select class="span6" ng-model="selTeamMember"
+                        <td><select class="span6" ng-model="sel.teamMember"
                                     ng-options="user.$id() as user.getFullName() for user in teamMemberCandidates()"></select>
                         </td>
                         <td>
-                            <button class="btn btn-small" ng-click="addTeamMember()" ng-disabled="!selTeamMember">Add
+                            <button class="btn btn-small" ng-click="addTeamMember()" ng-disabled="!sel.teamMember">Add
                             </button>
                         </td>
                     </tr>


### PR DESCRIPTION
Fixed bug where you couldn't manage users from the admin/projects form.

$scope.selTeamMember was bound to the parent scope. By making an attribute on a child object, the crud-edit directive child scope can now access it.
