### PR TITLE
Fixes adding a dev user to a project

### DIFF
--- a/client/src/app/admin/projects/admin-projects.js
+++ b/client/src/app/admin/projects/admin-projects.js
@@ -37,7 +37,7 @@ angular.module('admin-projects', [
 .controller('ProjectsEditCtrl', ['$scope', '$location', 'i18nNotifications', 'users', 'project', function($scope, $location, i18nNotifications, users, project) {
 
   $scope.project = project;
-  $scope.selTeamMember = undefined;
+  $scope.selTeamMember = {};
 
   $scope.users = users;
   //prepare users lookup, just keep references for easier lookup
@@ -76,10 +76,10 @@ angular.module('admin-projects', [
   };
 
   $scope.addTeamMember = function() {
-    if($scope.selTeamMember) {
-      $scope.project.teamMembers.push($scope.selTeamMember);
-      $scope.selTeamMember = undefined;
-    }
+      if ($scope.selTeamMember.member != null) {
+          $scope.project.teamMembers.push($scope.selTeamMember.member);
+          $scope.selTeamMember = {};
+      }
   };
 
   $scope.removeTeamMember = function(teamMember) {

--- a/client/src/app/admin/projects/projects-edit.tpl.html
+++ b/client/src/app/admin/projects/projects-edit.tpl.html
@@ -36,11 +36,11 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><select class="span6" ng-model="selTeamMember"
+                        <td><select class="span6" ng-model="selTeamMember.member"
                                     ng-options="user.$id() as user.getFullName() for user in teamMemberCandidates()"></select>
                         </td>
                         <td>
-                            <button class="btn btn-small" ng-click="addTeamMember()" ng-disabled="!selTeamMember">Add
+                            <button class="btn btn-small" ng-click="addTeamMember()" ng-disabled="selTeamMember.member == null">Add
                             </button>
                         </td>
                     </tr>


### PR DESCRIPTION
Hitting the "add" button doesn't work for adding dev users to a project. It appears the problem is a scope issue. By working with an object model rather than referencing the value directly we avoid the scope collision.

Adding users was not working because $scope.selTeamMember was always
undefined in the controller. However, bindings on the "selTeamMember"
model in the HTML worked correctly. So there must be an implicit sibling
scope involved for some reason. Changing the model to be an object
instead removes ambiguity for Angular and the interaction now works as
expected.
