### PR TITLE
FIX proposal - tasks cannot be added to sprints

### DIFF
--- a/client/src/common/directives/crud/edit.js
+++ b/client/src/common/directives/crud/edit.js
@@ -40,7 +40,7 @@ angular.module('directives.crud.edit', [])
       };
       // Set up callbacks with fallback
       // onSave attribute -> onSave scope -> noop
-      var userOnSave = attrs.onSave ? makeFn('onSave') : ( $parent.scope.onSave || angular.noop );
+      var userOnSave = attrs.onSave ? makeFn('onSave') : ( scope.onSave || angular.noop );
       var onSave = function(result, status, headers, config) {
         // Reset the original to help with reverting and pristine checks
         original = result;


### PR DESCRIPTION
See Issue #206
Since crudEdit directive defines a new child scope, properties defined in crudEditMethods object should be used with $parent.scope reference.
