### PR TITLE
Fixed crud-buttons markup position to be compliant with crudEdit directive

### DIFF
--- a/client/src/app/projects/sprints/tasks/tasks-edit.tpl.html
+++ b/client/src/app/projects/sprints/tasks/tasks-edit.tpl.html
@@ -1,6 +1,6 @@
-<div class="well">
-    <div class="row-fluid">
-        <form name="form" crud-edit="task">
+<form name="form" crud-edit="task">
+    <div class="well">
+        <div class="row-fluid">
             <div class="span6">
                 <label>Name</label>
                 <input type="text" name="name" ng-model="task.name" class="span10" required autofocus>
@@ -19,9 +19,9 @@
                 <select name="state" ng-model="task.state" class="span5" required ng-options="state for state in statesEnum"></select>
                 <label>Assigned to</label>
                 <select name="state" ng-model="task.assignedUserId" class="span10" ng-options="teamMember.$id() as teamMember.getFullName() for teamMember in teamMembers"></select>
-            </div>
-        </form>
+            </div>            
+        </div>
+        <hr>
+        <crud-buttons></crud-buttons>
     </div>
-    <hr>
-    <crud-buttons></crud-buttons>
-</div>
+</form>


### PR DESCRIPTION
Fix for issue #206
***crudEdit*** directive defines an isolated scope and requires FormController.
To see FormController's scope (which exposes save(), canSave() etc.) ***crud-buttons*** markup must be a ***form*** child in ***task-edit.tpl.html***